### PR TITLE
Fix/gitlab in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ the documentation is in the folder [docs] [1]
 
 The instructions for the installation are in the file [installation.md] [2]
 
-[1]: docs/README.md
+[1]: docs/
 [2]: docs/installation.md

--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ the documentation is in the folder [docs] [1]
 
 The instructions for the installation are in the file [installation.md] [2]
 
-[1]: https://gitlab.com/Indaym/Web-Indaym/tree/master/docs
-[2]: https://gitlab.com/Indaym/Web-Indaym/blob/master/docs/installation.md
+[1]: docs/README.md
+[2]: docs/installation.md


### PR DESCRIPTION
Fix des liens gitlab oubliés dans le Readme

Issue :
#9 

Note : 
J'ai rajouté les liens en dynamique pour éviter ce genre de désagréments à l'avenir.